### PR TITLE
Potential issue in code/AssetLib/glTF/glTFExporter.cpp: Unchecked return from initialization function

### DIFF
--- a/code/AssetLib/glTF/glTFExporter.cpp
+++ b/code/AssetLib/glTF/glTFExporter.cpp
@@ -281,7 +281,7 @@ void glTFExporter::GetTexSampler(const aiMaterial* mat, glTF::TexProperty& prop)
     std::string samplerId = mAsset->FindUniqueID("", "sampler");
     prop.texture->sampler = mAsset->samplers.Create(samplerId);
 
-    aiTextureMapMode mapU, mapV;
+    aiTextureMapMode mapU = 0, mapV = 0;
     aiGetMaterialInteger(mat,AI_MATKEY_MAPPINGMODE_U_DIFFUSE(0),(int*)&mapU);
     aiGetMaterialInteger(mat,AI_MATKEY_MAPPINGMODE_V_DIFFUSE(0),(int*)&mapV);
 


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

2 instances of this defect were found in the following locations:
---
**Instance 1**
File : `code/AssetLib/glTF/glTFExporter.cpp` 
Function: `aiGetMaterialInteger` 
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/glTF/glTFExporter.cpp#L285
Check out:mapU

Code extract:

```cpp
    prop.texture->sampler = mAsset->samplers.Create(samplerId);

    aiTextureMapMode mapU, mapV;
    aiGetMaterialInteger(mat,AI_MATKEY_MAPPINGMODE_U_DIFFUSE(0),(int*)&mapU); <------ HERE
    aiGetMaterialInteger(mat,AI_MATKEY_MAPPINGMODE_V_DIFFUSE(0),(int*)&mapV);

```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 2**
File : `code/AssetLib/glTF/glTFExporter.cpp` 
Function: `aiGetMaterialInteger` 
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/glTF/glTFExporter.cpp#L286
Check out:mapV

Code extract:

```cpp

    aiTextureMapMode mapU, mapV;
    aiGetMaterialInteger(mat,AI_MATKEY_MAPPINGMODE_U_DIFFUSE(0),(int*)&mapU);
    aiGetMaterialInteger(mat,AI_MATKEY_MAPPINGMODE_V_DIFFUSE(0),(int*)&mapV); <------ HERE

    switch (mapU) {
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
