### PR TITLE
Potential issue in code/AssetLib/NFF/NFFLoader.cpp: Unchecked return from initialization function

### DIFF
--- a/code/AssetLib/NFF/NFFLoader.cpp
+++ b/code/AssetLib/NFF/NFFLoader.cpp
@@ -158,7 +158,7 @@ void NFFImporter::LoadNFF2MaterialTable(std::vector<ShadingInfo> &output,
 
     // No read the file line per line
     char line[4096];
-    const char *sz;
+    const char *sz = nullptr;
     while (GetNextLine(buffer, line)) {
         SkipSpaces(line, &sz);
 
@@ -229,7 +229,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
     std::vector<MeshInfo> meshesLocked;
 
     char line[4096];
-    const char *sz;
+    const char *sz = nullptr;
 
     // camera parameters
     aiVector3D camPos, camUp(0.f, 1.f, 0.f), camLookAt(0.f, 0.f, 1.f);
@@ -937,7 +937,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
             }
             // '' - comment
             else if ('#' == line[0]) {
-                const char *space;
+                const char *space = nullptr;
                 SkipSpaces(&line[1], &space);
                 if (!IsLineEnd(*space)) {
                     ASSIMP_LOG_INFO(space);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

9 instances of this defect were found in the following locations:
---
**Instance 1**
File : `code/AssetLib/NFF/NFFLoader.cpp` 
Function: `$SkipSpaces@D@Assimp` 
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/NFF/NFFLoader.cpp#L163
**Check out**: _sz_

**Code extract**:

```cpp
    char line[4096];
    const char *sz;
    while (GetNextLine(buffer, line)) {
        SkipSpaces(line, &sz); <------ HERE

        // 'version' defines the version of the file format
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 2**
File : `code/AssetLib/NFF/NFFLoader.cpp` 
Function: `$SkipSpaces@D@Assimp` 
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/NFF/NFFLoader.cpp#L189
**Check out**: _sz_

**Code extract**:

```cpp
            // now read the material property and determine its type
            aiColor3D c;
            if (TokenMatch(sz, "ambient", 7)) {
                AI_NFF_PARSE_TRIPLE(c); <------ HERE
                curShader->ambient = c;
            } else if (TokenMatch(sz, "diffuse", 7) || TokenMatch(sz, "ambientdiffuse", 14) /* correct? */) {
```

**How can I fix it?** 
Correct reference usage found in `code/AssetLib/XGL/XGLLoader.cpp` at line `924`.
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/XGL/XGLLoader.cpp#L924
**Code extract**:

```cpp
    const char* s = m_reader->getNodeData();

    for(int i = 0; i < 3; ++i) {
        if(!SkipSpaces(&s)) { <------ HERE
            LogError("unexpected EOL, failed to parse vec3");
            return vec;
```

---
**Instance 3**
File : `code/AssetLib/NFF/NFFLoader.cpp` 
Function: `$SkipSpaces@D@Assimp` 
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/NFF/NFFLoader.cpp#L189
**Check out**: _sz_

**Code extract**:

```cpp
            // now read the material property and determine its type
            aiColor3D c;
            if (TokenMatch(sz, "ambient", 7)) {
                AI_NFF_PARSE_TRIPLE(c); <------ HERE
                curShader->ambient = c;
            } else if (TokenMatch(sz, "diffuse", 7) || TokenMatch(sz, "ambientdiffuse", 14) /* correct? */) {
```

**How can I fix it?** 
Correct reference usage found in `code/AssetLib/XGL/XGLLoader.cpp` at line `924`.
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/XGL/XGLLoader.cpp#L924
**Code extract**:

```cpp
    const char* s = m_reader->getNodeData();

    for(int i = 0; i < 3; ++i) {
        if(!SkipSpaces(&s)) { <------ HERE
            LogError("unexpected EOL, failed to parse vec3");
            return vec;
```

---
**Instance 4**
File : `code/AssetLib/NFF/NFFLoader.cpp` 
Function: `$SkipSpaces@D@Assimp` 
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/NFF/NFFLoader.cpp#L189
**Check out**: _sz_

**Code extract**:

```cpp
            // now read the material property and determine its type
            aiColor3D c;
            if (TokenMatch(sz, "ambient", 7)) {
                AI_NFF_PARSE_TRIPLE(c); <------ HERE
                curShader->ambient = c;
            } else if (TokenMatch(sz, "diffuse", 7) || TokenMatch(sz, "ambientdiffuse", 14) /* correct? */) {
```

**How can I fix it?** 
Correct reference usage found in `code/AssetLib/XGL/XGLLoader.cpp` at line `924`.
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/XGL/XGLLoader.cpp#L924
**Code extract**:

```cpp
    const char* s = m_reader->getNodeData();

    for(int i = 0; i < 3; ++i) {
        if(!SkipSpaces(&s)) { <------ HERE
            LogError("unexpected EOL, failed to parse vec3");
            return vec;
```

---
**Instance 5**
File : `code/AssetLib/NFF/NFFLoader.cpp` 
Function: `$SkipSpaces@D@Assimp` 
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/NFF/NFFLoader.cpp#L278
**Check out**: _sz_

**Code extract**:

```cpp
        CommentRemover::RemoveLineComments("//", &mBuffer2[0]);

        while (GetNextLine(buffer, line)) {
            SkipSpaces(line, &sz); <------ HERE
            if (TokenMatch(sz, "version", 7)) {
                ASSIMP_LOG_INFO_F("NFF (Sense8) file format: ", sz);
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 6**
File : `code/AssetLib/NFF/NFFLoader.cpp` 
Function: `$SkipSpaces@D@Assimp` 
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/NFF/NFFLoader.cpp#L282
**Check out**: _sz_

**Code extract**:

```cpp
            if (TokenMatch(sz, "version", 7)) {
                ASSIMP_LOG_INFO_F("NFF (Sense8) file format: ", sz);
            } else if (TokenMatch(sz, "viewpos", 7)) {
                AI_NFF_PARSE_TRIPLE(camPos); <------ HERE
                hasCam = true;
            } else if (TokenMatch(sz, "viewdir", 7)) {
```

**How can I fix it?** 
Correct reference usage found in `code/AssetLib/XGL/XGLLoader.cpp` at line `924`.
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/XGL/XGLLoader.cpp#L924
**Code extract**:

```cpp
    const char* s = m_reader->getNodeData();

    for(int i = 0; i < 3; ++i) {
        if(!SkipSpaces(&s)) { <------ HERE
            LogError("unexpected EOL, failed to parse vec3");
            return vec;
```

---
**Instance 7**
File : `code/AssetLib/NFF/NFFLoader.cpp` 
Function: `$SkipSpaces@D@Assimp` 
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/NFF/NFFLoader.cpp#L282
**Check out**: _sz_

**Code extract**:

```cpp
            if (TokenMatch(sz, "version", 7)) {
                ASSIMP_LOG_INFO_F("NFF (Sense8) file format: ", sz);
            } else if (TokenMatch(sz, "viewpos", 7)) {
                AI_NFF_PARSE_TRIPLE(camPos); <------ HERE
                hasCam = true;
            } else if (TokenMatch(sz, "viewdir", 7)) {
```

**How can I fix it?** 
Correct reference usage found in `code/AssetLib/XGL/XGLLoader.cpp` at line `924`.
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/XGL/XGLLoader.cpp#L924
**Code extract**:

```cpp
    const char* s = m_reader->getNodeData();

    for(int i = 0; i < 3; ++i) {
        if(!SkipSpaces(&s)) { <------ HERE
            LogError("unexpected EOL, failed to parse vec3");
            return vec;
```

---
**Instance 8**
File : `code/AssetLib/NFF/NFFLoader.cpp` 
Function: `$SkipSpaces@D@Assimp` 
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/NFF/NFFLoader.cpp#L282
**Check out**: _sz_

**Code extract**:

```cpp
            if (TokenMatch(sz, "version", 7)) {
                ASSIMP_LOG_INFO_F("NFF (Sense8) file format: ", sz);
            } else if (TokenMatch(sz, "viewpos", 7)) {
                AI_NFF_PARSE_TRIPLE(camPos); <------ HERE
                hasCam = true;
            } else if (TokenMatch(sz, "viewdir", 7)) {
```

**How can I fix it?** 
Correct reference usage found in `code/AssetLib/XGL/XGLLoader.cpp` at line `924`.
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/XGL/XGLLoader.cpp#L924
**Code extract**:

```cpp
    const char* s = m_reader->getNodeData();

    for(int i = 0; i < 3; ++i) {
        if(!SkipSpaces(&s)) { <------ HERE
            LogError("unexpected EOL, failed to parse vec3");
            return vec;
```

---
**Instance 9**
File : `code/AssetLib/NFF/NFFLoader.cpp` 
Function: `$SkipSpaces@D@Assimp` 
https://github.com/sagpant/assimp/blob/1427e67b54906419e9f83cc8625e2207fbb0fcd5/code/AssetLib/NFF/NFFLoader.cpp#L941
**Check out**: _space_

**Code extract**:

```cpp
            // '' - comment
            else if ('#' == line[0]) {
                const char *space;
                SkipSpaces(&line[1], &space); <------ HERE
                if (!IsLineEnd(*space)) {
                    ASSIMP_LOG_INFO(space);
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
